### PR TITLE
Fixing issue #3

### DIFF
--- a/aiochannel/channel.py
+++ b/aiochannel/channel.py
@@ -165,11 +165,13 @@ class Channel(object):
         self._close.set()
         # cancel putters
         for putter in self._putters:
-            putter.set_exception(ChannelClosed())
+            if not putter.cancelled():
+                putter.set_exception(ChannelClosed())
         # cancel getters that can't ever return (as no more items can be added)
         while len(self._getters) > self.qsize():
             getter = self._getters.pop()
-            getter.set_exception(ChannelClosed())
+            if not getter.cancelled():
+                getter.set_exception(ChannelClosed())
 
         if self.empty():
             # already empty, mark as finished

--- a/tests/regressions/test_invalid_state_error_during_close.py
+++ b/tests/regressions/test_invalid_state_error_during_close.py
@@ -1,0 +1,26 @@
+import aiounittest
+import asyncio
+from aiochannel import Channel
+
+
+class Issue3(aiounittest.AsyncTestCase):
+    async def test_invalid_state_error_during_close(self):
+        """Getter is waiting in a task, getter is cancelled from here,
+           then channel is closed before yielding loop.
+           This is the actual issue reported in issue #3."""
+        c = Channel(3)
+        getter_task = asyncio.ensure_future(c.get())
+        await asyncio.sleep(0)
+        getter_task.cancel()
+        c.close()
+
+    async def test_invalid_state_error_during_close_putter(self):
+        """This case is the same idea as above but with a putter
+           instead of a getter"""
+        c = Channel(1)
+        # add an item, filling the queue, allowing is to produce a putter:
+        await c.put(1)
+        task = asyncio.ensure_future(c.put(2))
+        await asyncio.sleep(0)
+        task.cancel()
+        c.close()

--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ envlist = py39,
 [testenv]
 deps = -r{toxinidir}/tools/test-requirements.txt
 commands = {toxinidir}/tools/clean.sh {toxinidir}/aiochannel
-           coverage run
+           coverage run -m unittest {posargs}
            coverage report
 
 [testenv:pep8]


### PR DESCRIPTION
When a getter or putter future was cancelled from the outside but not
yet removed from the _getters / _putters deque, and then calling close(),
an InvalidStateError was thrown when blindly calling set_exception before
checking if the future was cancelled.

I've previously used future.done() check here, but I don't want that,
because I _want_ this code to fail if a _value_ has been previously set
on these futures. However, as @stijn-devriendt corrected pointed out,
these futures can be cancelled from the outside, which should be a valid
operation.

I've implemented a check to see if a putter/getter is already cancelled
before setting the ChannelClosed exception on close().

I've also considered what happens if we have a lot of putters/getters
in the deque that has been cancelled. I could remove them by hooking up
a done callback to the futures, but I don't think this necesary because
if a putter/getter is already marked done, it will simply be popped and skipped
when it is it's turn in the deque, so cleaning up will happen automatically
once the cancelled future reaches the head of the deque.

For almost all use-cases I can think of, that is both good enough, and probably
also usually better as to not have to search a large deque every time a future
is cancelled to make sure we remove it.