### PR TITLE
Removing py36, Adding py310, setting allowlist_externals to clean.sh

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: '3.6'
-            toxenv: py36
           - python-version: '3.7'
             toxenv: py37
           - python-version: '3.8'

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,13 @@
 envlist = py39,
           py38,
           py37,
-          py36,
+          py310,
           pep8,
           pylint,
 
+
 [testenv]
+allowlist_externals={toxinidir}/tools/clean.sh
 deps = -r{toxinidir}/tools/test-requirements.txt
 commands = {toxinidir}/tools/clean.sh {toxinidir}/aiochannel
            coverage run -m unittest {posargs}


### PR DESCRIPTION
Needed to add `allowlist_externals` to tox.ini.

At the same time, adding py310 and removing py36.