### PR TITLE
Fixes #13

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -137,6 +137,9 @@ explicitly, your IDE or mypy will follow this annotations.
     channel: Channel[str] = Channel(100)
 
 
+Fixing issue #13 that could lead to "getters" waiting forever
+when a channel was closed with less items then pending getters.
+
 0.2.0
 ^^^^^
 

--- a/aiochannel/channel.py
+++ b/aiochannel/channel.py
@@ -183,6 +183,11 @@ class Channel(Generic[T]):
             if not getter.cancelled():
                 getter.set_exception(ChannelClosed())
 
+        # the remaining getters can now be woken up:
+        while self._getters:
+            self._wakeup_next(self._getters)
+
+        # if channel is already empty, mark finished:
         if self.empty():
             # already empty, mark as finished
             self._finished.set()

--- a/tests/regressions/test_stuck_if_more_getters_than_items.py
+++ b/tests/regressions/test_stuck_if_more_getters_than_items.py
@@ -1,0 +1,48 @@
+import aiounittest
+import asyncio
+from aiochannel import Channel
+
+
+class Issue13(aiounittest.AsyncTestCase):
+
+    async def test_stuck_if_more_getters_than_items(self):
+        """
+        This is taken literally from issue #13
+        """
+
+        async def dummy_worker(ch):
+            async for item in ch:
+                pass
+
+        concurrency = 2
+        ch = Channel()
+        tasks = [asyncio.create_task(dummy_worker(ch)) for _ in range(concurrency)]
+
+        # Imagine we get items list asynchroniosly from web or moreover,
+        # via async generator from stream and we do not know how items are there.
+        # if i remove this context switch - everything works fine
+        await asyncio.sleep(0)
+        items = [1]
+
+        for item in items:
+            await ch.put(item)
+
+        ch.close()
+        await asyncio.gather(*tasks)
+
+    async def test_getters_can_still_arrive_late(self):
+        async def dummy_worker(ch):
+            async for item in ch:
+                pass
+
+        ch = Channel()
+
+        for item in [1, 2, 3]:
+            await ch.put(item)
+        ch.close()
+
+        tasks = [asyncio.create_task(dummy_worker(ch)) for _ in range(2)]
+        await asyncio.gather(*tasks)
+
+        assert ch.closed()
+        assert ch.empty()


### PR DESCRIPTION
`close` will mark the channel as closed, but only cancel getters that _cannot_ be satisfied by the remaining items in the channel.

The problem is that nobody ever told the remaining getters that they could proceed, leading to waiting forever.

This fix will wake up the remaining getters, such that when `close` completes, there should be no more pending getters or putters.

New getters can ofc. arrive later as normal.