### PR TITLE
Transition from deprecated pkg_resources

### DIFF
--- a/aiochannel/__init__.py
+++ b/aiochannel/__init__.py
@@ -1,8 +1,8 @@
 from .channel import Channel
 from .errors import ChannelClosed, ChannelFull, ChannelEmpty
 
-import pkg_resources
-__version__ = pkg_resources.get_distribution("aiochannel").version
+import importlib.metadata
+__version__ = importlib.metadata.version("aiochannel")
 
 
 __all__ = [


### PR DESCRIPTION
`pkg_resources` is [deprecated](https://setuptools.pypa.io/en/latest/pkg_resources.html). This transitions to `importlib.metadata`.