### PR TITLE
chore(deps): drop EOL python 3.9, add python 3.14

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,8 +16,6 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - python-version: "3.9"
-            toxenv: py39
           - python-version: "3.10"
             toxenv: py310
           - python-version: "3.11"
@@ -26,9 +24,11 @@ jobs:
             toxenv: py312
           - python-version: "3.13"
             toxenv: py313
-          - python-version: "3.13"
+          - python-version: "3.14"
+            toxenv: py314
+          - python-version: "3.14"
             toxenv: pylama
-          - python-version: "3.13"
+          - python-version: "3.14"
             toxenv: mypy
     steps:
       - uses: actions/checkout@v2

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -16,11 +16,11 @@ classifiers = [
   "Operating System :: MacOS :: MacOS X",
   "Operating System :: Microsoft :: Windows",
   "Operating System :: POSIX",
-  "Programming Language :: Python :: 3.9",
   "Programming Language :: Python :: 3.10",
   "Programming Language :: Python :: 3.11",
   "Programming Language :: Python :: 3.12",
   "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
   "Programming Language :: Python :: 3 :: Only",
   "Framework :: AsyncIO",
   "Typing :: Typed",
@@ -32,7 +32,7 @@ packages = [{ include = "aiochannel" }]
 "Tracker" = "https://github.com/tudborg/aiochannel/issues"
 
 [tool.poetry.dependencies]
-python = "^3.9"
+python = "^3.10"
 
 [tool.poetry.group.dev.dependencies]
 pylint = "^3.3.2"
@@ -44,7 +44,7 @@ pytest-cov = "5"
 types-setuptools = "^67.3.0.1"
 pytest-codeblocks = "^0.17.0"
 pylama = "^8.4.1"
-setuptools = ">=75.6,<79.0"
+setuptools = ">=75.6,<83.0"
 
 [build-system]
 requires = ["poetry-core"]

--- a/tox.ini
+++ b/tox.ini
@@ -1,9 +1,9 @@
 [tox]
-envlist = py313,
+envlist = py314,
+          py313,
           py312,
           py311,
           py310,
-          py39,
           pylama,
           mypy,
 


### PR DESCRIPTION
- Remove Python 3.9 (EOL Oct 2025) from classifiers, CI matrix, and tox
- Add Python 3.14 to classifiers, CI matrix, and tox
- Bump minimum Python requirement from 3.9 to 3.10
- Raise setuptools upper bound from <79.0 to <83.0 for 3.14 compat